### PR TITLE
Integrate Ryan Ball's 5/17/19 Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 dockbuilder.sh.old
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Some things to keep in mind:
 1. Within both the breadcrumb and log variables, you'll notice the $HOME environmental variable. You should leave this in there as both should be in the user's home folder.
 2. Within the defaultItemsToAdd array (and alternateItemsToAdd_1 if you use it), you need to follow the same pattern that I used in the example. When specifying view options for the persistent-others Dock items, you need to separate the Dock item and options with a comma (",") as per the example.
 3. After modifying the variables in build.sh, please test for full functionality before deploying.
-4. If you want to set up a unique Dock for certain users you must populate the alternateItemsToAdd_1 ion [build.sh](/build.sh) **and** modify [this logic in dockbuilder.sh]([/dockbuilder.sh](https://github.com/ryangball/DockBuilder/blob/024aa453ce729b786565b32ed559f3ca757fdfb9/dockbuilder.sh#L108-L119)) to include the users or criteria to build the alternate Dock.
+4. If you want to set up a unique Dock for certain users you must populate the alternateItemsToAdd_1 ion [build.sh](/build.sh) **and** modify [this logic in dockbuilder.sh](https://github.com/ryangball/DockBuilder/blob/e6c4bab519648bdcdc812293bdd0ad098a798cc9/dockbuilder.sh#L108-L119)) to include the users or criteria to build the alternate Dock.
 5. If you want to exclude specific existing users from the initial breadcrumb creation so that they will get a new Dock created, you must populate the skipInitialBreadcrumbUsers variable in [build.sh](/build.sh).
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ DockBuilder allows for the building of a user's Dock based on an organization's 
 
 ## Features
 - Builds a Dock based on pre-defined defaults
+- Includes a framework for building unique Docks for certain users based on some criteria (including an example)
 - Logs to ~/Library/Logs/DockBuilder.log (by default)
 - Does not start until the Dock.app is loaded upon login
 - Only builds a Dock for user's who's Dock is younger than 300 seconds (to minimize re-building a pre-existing user's Dock after the installation of DockBuilder)
@@ -38,10 +39,11 @@ cd DockBuilder
 Within the [build.sh](/build.sh) script, you can modify the top-most variables to create a custom DockBuilder .app and .pkg.
 
 Some things to keep in mind:
-1. If you change the breadcrumb variable, you'll need to update that in the postinstall as the postinstall uses slightly different path structure within the for loop around line 25.
-2. Within both the breadcrumb and log variables, you'll notice the $HOME environmental variable. You should leave this in there as both should be in the user's home folder.
-3. Within the defaultItemsToAdd array, you need to follow the same pattern that I used in the example. When specifying view options for the persistent-others Dock items, you need to separate the Dock item and options with a comma (",") as per the example.
-4. After modifying the variables in build.sh, please test for full functionality before deploying.
+1. Within both the breadcrumb and log variables, you'll notice the $HOME environmental variable. You should leave this in there as both should be in the user's home folder.
+2. Within the defaultItemsToAdd array (and alternateItemsToAdd_1 if you use it), you need to follow the same pattern that I used in the example. When specifying view options for the persistent-others Dock items, you need to separate the Dock item and options with a comma (",") as per the example.
+3. After modifying the variables in build.sh, please test for full functionality before deploying.
+4. If you want to set up a unique Dock for certain users you must populate the alternateItemsToAdd_1 ion [build.sh](/build.sh) **and** modify [this logic in dockbuilder.sh]([/dockbuilder.sh](https://github.com/ryangball/DockBuilder/blob/024aa453ce729b786565b32ed559f3ca757fdfb9/dockbuilder.sh#L108-L119)) to include the users or criteria to build the alternate Dock.
+5. If you want to exclude specific existing users from the initial breadcrumb creation so that they will get a new Dock created, you must populate the skipInitialBreadcrumbUsers variable in [build.sh](/build.sh).
 
 ## Testing
 To test DockBuilder, install the .pkg, then unload/load/start the LaunchAgent.

--- a/build.sh
+++ b/build.sh
@@ -75,7 +75,7 @@ function install_dockutil_pkg () {
     else
         pkgutil --expand-full "$PWD/dockutil.pkg" /private/tmp/DockBuilder/temp
         cp -R /private/tmp/DockBuilder/temp/Payload/usr /private/tmp/DockBuilder/files/
-        rm -R /private/tmp/DOckBuilder/temp
+        rm -R /private/tmp/DockBuilder/temp
     fi
 
     if [[ ! -e /private/tmp/DockBuilder/files/usr/local/bin/dockutil ]]; then
@@ -134,11 +134,11 @@ fi
 /usr/libexec/PlistBuddy -c "Add :SkipInitialBreadcrumbUsers array" "$PWD/$preferenceFileName"
 
 # Populate our variables into the plist
-defaults write "$PWD/$preferenceFileName" BreadcrumbPath -string "$breadcrumb"
-defaults write "$PWD/$preferenceFileName" LogPath -string "$log"
-defaults write "$PWD/$preferenceFileName" AppIcon -string "$appIcon"
-defaults write "$PWD/$preferenceFileName" HideDockWhileBuilding -bool "$hideDockWhileBuilding"
-defaults write "$PWD/$preferenceFileName" HideDockMessage -string "$hideDockMessage"
+/usr/bin/plutil -insert BreadcrumbPath -string "$breadcrumb" "$PWD/$preferenceFileName"
+/usr/bin/plutil -insert LogPath -string "$log" "$PWD/$preferenceFileName"
+/usr/bin/plutil -insert AppIcon -string "$appIcon" "$PWD/$preferenceFileName"
+/usr/bin/plutil -insert HideDockWhileBuilding -bool "$hideDockWhileBuilding" "$PWD/$preferenceFileName"
+/usr/bin/plutil -insert HideDockMessage -string "$hideDockMessage" "$PWD/$preferenceFileName"
 
 # Populate our DefaultItemsToAdd array
 index="0"

--- a/com.github.ryangball.dockbuilder.defaults.plist
+++ b/com.github.ryangball.dockbuilder.defaults.plist
@@ -2,15 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AlternateItemsToAdd_1</key>
+	<array>
+		<string>/Applications/System Preferences.app/</string>
+		<string>/Applications/Safari.app/</string>
+		<string>/Applications/App Store.app/</string>
+		<string>/System/Library/CoreServices/Applications/Directory Utility.app/</string>
+		<string>/Applications/Utilities/Activity Monitor.app/</string>
+		<string>/Applications/Utilities/Console.app/</string>
+		<string>/Applications/Utilities/Terminal.app/</string>
+		<string>/System/Library/CoreServices/Applications/Network Utility.app/</string>
+		<string>/Applications/Utilities/Disk Utility.app/</string>
+		<string>/Applications/Utilities/Keychain Access.app/</string>
+		<string>/Applications/,--view grid --display stack --sort name</string>
+		<string>~/Downloads</string>
+	</array>
 	<key>AppIcon</key>
 	<string>/System/Library/CoreServices/Dock.app/Contents/Resources/Dock.icns</string>
 	<key>BreadcrumbPath</key>
 	<string>$HOME/Library/Preferences/com.github.ryangball.dockbuilder.breadcrumb.plist</string>
-	<key>HideDockMessage</key>
-	<string>Your Mac's Dock is being built for the first time.</string>
-	<key>HideDockWhileBuilding</key>
-	<true/>
-	<key>ItemsToAdd</key>
+	<key>DefaultItemsToAdd</key>
 	<array>
 		<string>/Applications/System Preferences.app/</string>
 		<string>/Applications/Self Service.app/</string>
@@ -22,7 +33,16 @@
 		<string>/Applications/,--view grid --display stack --sort name</string>
 		<string>~/Downloads</string>
 	</array>
+	<key>HideDockMessage</key>
+	<string>Your Mac's Dock is being built for the first time.</string>
+	<key>HideDockWhileBuilding</key>
+	<true/>
 	<key>LogPath</key>
 	<string>$HOME/Library/Logs/DockBuilder.log</string>
+	<key>SkipInitialBreadcrumbUsers</key>
+	<array>
+		<string>admin2</string>
+		<string>admin</string>
+	</array>
 </dict>
 </plist>

--- a/dockbuilder.sh
+++ b/dockbuilder.sh
@@ -16,28 +16,6 @@ alternateItemsToAdd_1FromPlist=$(/usr/libexec/PlistBuddy -c "Print AlternateItem
 loggedInUser=$(/usr/sbin/scutil <<< "show State:/Users/ConsoleUser" | /usr/bin/awk '/Name :/ && ! /loginwindow/ { print $3 }')
 scriptName=$(basename "$0")
 
-# Validate we got values from the plist
-if [[ -f "$preferenceFileFullPath" ]]; then
-	# Create array for default items
-	while read -r line; do
-		defaultItemsToAdd+=("$line")
-	done <<< "$defaultItemsToAddFromPlist"
-
-	# Create array for alternate_1 items
-	while read -r line; do
-		alternateItemsToAdd_1+=("$line")
-	done <<< "$alternateItemsToAdd_1FromPlist"
-
-	# Verify that we obtained values for each variable
-	if [[ -z "$breadcrumb" ]] || [[ -z "$log" ]] || [[ -z "$appIcon" ]] || [[ -z "$hideDockWhileBuilding" ]] || [[ -z "$hideDockMessage" ]] || [[ -z "${defaultItemsToAdd[*]}" ]]; then
-		writelog "One or more default settings not present in main preference file; exiting."
-		finish 1
-	fi
-else
-	writelog "Preference file does not exist; exiting."
-	finish 1
-fi
-
 function writelog () {
     DATE=$(date +%Y-%m-%d\ %H:%M:%S)
     /bin/echo "${1}"
@@ -47,7 +25,6 @@ function writelog () {
 function finish () {
 	kill "$jamfHelperPID" 2>/dev/null; wait "$jamfHelperPID" 2>/dev/null
     writelog "======== Finished $scriptName ========"
-    exit "$1"
 }
 
 function build_dock () {
@@ -70,13 +47,37 @@ function create_breadcrumb () {
 	/usr/bin/defaults write "$breadcrumb" build-time "$(date +%r)"
 }
 
+trap finish EXIT
+
 writelog " "
 writelog "======== Starting $scriptName ========"
+
+# Validate we got values from the plist
+if [[ -f "$preferenceFileFullPath" ]]; then
+	# Create array for default items
+	while read -r line; do
+		defaultItemsToAdd+=("$line")
+	done <<< "$defaultItemsToAddFromPlist"
+
+	# Create array for alternate_1 items
+	while read -r line; do
+		alternateItemsToAdd_1+=("$line")
+	done <<< "$alternateItemsToAdd_1FromPlist"
+
+	# Verify that we obtained values for each variable
+	if [[ -z "$breadcrumb" ]] || [[ -z "$log" ]] || [[ -z "$appIcon" ]] || [[ -z "$hideDockWhileBuilding" ]] || [[ -z "$hideDockMessage" ]] || [[ -z "${defaultItemsToAdd[*]}" ]]; then
+		writelog "One or more default settings not present in main preference file; exiting."
+		exit 1
+	fi
+else
+	writelog "Preference file does not exist; exiting."
+	exit 1
+fi
 
 # Make sure DockUtil is installed
 if [[ ! -f "/usr/local/bin/dockutil" ]]; then
 	writelog "DockUtil does not exist, exiting."
-	finish 1
+	exit 1
 fi
 
 # We need to wait for the Dock to actually start
@@ -87,7 +88,7 @@ done
 # Check to see if the Dock was previously set up for the user
 if [[ -f "$breadcrumb" ]]; then
 	writelog "DockBuilder ran previously on $(defaults read "$breadcrumb" build-date) at $(defaults read "$breadcrumb" build-time)."
-	finish 0
+	exit 0
 fi
 
 if [[ "$hideDockWhileBuilding" == "true" ]]; then
@@ -130,4 +131,4 @@ else
 	/usr/bin/killall Dock
 fi
 
-finish 0
+exit 0

--- a/dockbuilder.sh
+++ b/dockbuilder.sh
@@ -13,7 +13,7 @@ hideDockWhileBuilding=$(/usr/libexec/PlistBuddy -c "Print :HideDockWhileBuilding
 hideDockMessage=$(/usr/libexec/PlistBuddy -c "Print :HideDockMessage" "$preferenceFileFullPath")
 defaultItemsToAddFromPlist=$(/usr/libexec/PlistBuddy -c "Print DefaultItemsToAdd:" "$preferenceFileFullPath" | grep '/' | sed 's/^ *//')
 alternateItemsToAdd_1FromPlist=$(/usr/libexec/PlistBuddy -c "Print AlternateItemsToAdd_1:" "$preferenceFileFullPath" | grep '/' | sed 's/^ *//')
-loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+loggedInUser=$(/usr/sbin/scutil <<< "show State:/Users/ConsoleUser" | /usr/bin/awk '/Name :/ && ! /loginwindow/ { print $3 }')
 scriptName=$(basename "$0")
 
 # Validate we got values from the plist

--- a/dockbuilder.sh
+++ b/dockbuilder.sh
@@ -3,7 +3,7 @@
 # These variables will be replaced with values from the build.sh script automagically
 preferenceFileFullPath="/Library/Preferences/com.github.ryangball.dockbuilder.defaults.plist"
 
-########### It is not necessary to edit beyond this poing, do at your own risk ###########
+########### It is not necessary to edit beyond this point, do at your own risk ###########
 # These variables are populated from the main preference file, created
 # with the build.sh script and deployed to clients using resulting .pkg
 breadcrumb=$(eval echo "$(/usr/libexec/PlistBuddy -c "Print :BreadcrumbPath" "$preferenceFileFullPath")")	# Using eval here to expand $HOME

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 #shellcheck disable=SC2012
 
+preferenceFileFullPath="/Library/Preferences/com.github.ryangball.dockbuilder.defaults.plist"
+skipInitialBreadcrumbUsers=$(/usr/libexec/PlistBuddy -c "Print SkipInitialBreadcrumbUsers" $preferenceFileFullPath | sed -e 1d -e '$d' | sed 's/^ *//')
+
 log="/Library/Logs/DockBuilder_Install.log"
 
 function writelog () {
@@ -21,6 +24,10 @@ writelog "Looping through all users to ensure Dock will be configured correctly.
 
 # Run through all normal accounts
 for userName in $(dscl . -list /Users uid | awk '$2 >= 100 && $0 !~ /^_/ { print $1 }'); do
+	if [[ "$skipInitialBreadcrumbUsers" =~ $userName ]]; then
+		writelog "Initial breadcrumb creation for $userName is being skipped."
+		continue
+	fi
 	userHome=$(/usr/bin/dscl . read "/Users/$userName" NFSHomeDirectory | cut -c 19-)
 	breadcrumb="$userHome/Library/Preferences/com.github.ryangball.dockbuilder.breadcrumb.plist"
 

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -2,6 +2,7 @@
 #shellcheck disable=SC2012
 
 preferenceFileFullPath="/Library/Preferences/com.github.ryangball.dockbuilder.defaults.plist"
+breadcrumbPathMinusHome=$(/usr/libexec/PlistBuddy -c "Print BreadcrumbPath" $preferenceFileFullPath | cut -d/  -f2-)
 skipInitialBreadcrumbUsers=$(/usr/libexec/PlistBuddy -c "Print SkipInitialBreadcrumbUsers" $preferenceFileFullPath | sed -e 1d -e '$d' | sed 's/^ *//')
 
 log="/Library/Logs/DockBuilder_Install.log"
@@ -29,7 +30,7 @@ for userName in $(dscl . -list /Users uid | awk '$2 >= 100 && $0 !~ /^_/ { print
 		continue
 	fi
 	userHome=$(/usr/bin/dscl . read "/Users/$userName" NFSHomeDirectory | cut -c 19-)
-	breadcrumb="$userHome/Library/Preferences/com.github.ryangball.dockbuilder.breadcrumb.plist"
+	breadcrumb="$userHome/$breadcrumbPathMinusHome"
 
 	# Check to see if a breadcrumb is already created in the user's home folder
 	if [[ -f "$breadcrumb" ]]; then


### PR DESCRIPTION
Allow for different Docks, allow user exclusion from initial breadcrumb creation
Eliminate the need to modify postinstall if you change the breadcrumb name/path
